### PR TITLE
Formatting + comment fix for CHAR_COUNT (82 -> 90).

### DIFF
--- a/lib/uuidTools.js
+++ b/lib/uuidTools.js
@@ -8,7 +8,7 @@ export function intToUUID(n) {
 
   // Layout the bits for SSN:
   // - 3 digits (9 bits) for area number
-  // - 2 digits (7 bits) for group number 
+  // - 2 digits (7 bits) for group number
   // - 4 digits (14 bits) for serial number
 
   const areaNumber = n & 0x1ffn; // 9 bits for 3 digits (000-999)
@@ -29,7 +29,7 @@ export function intToUUID(n) {
 
 const ROUND_CONSTANTS = [
   BigInt("0x123456789"), // Area number mixing constant
-  BigInt("0x987654321"), // Group number mixing constant 
+  BigInt("0x987654321"), // Group number mixing constant
   BigInt("0x246813579"), // Serial number mixing constant
   BigInt("0x135792468"), // Additional mixing for area
   BigInt("0x975318642"), // Additional mixing for group
@@ -50,7 +50,7 @@ const ROUNDS_USED = 4;
 
 // Password generation tools
 const CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()_+-=[]{}|;:,.<>?~`";
-const CHAR_COUNT = BigInt(CHARS.length); // 82 characters
+const CHAR_COUNT = BigInt(CHARS.length); // 90 characters
 
 // Calculate the number of passwords for each length
 const PASSWORDS_PER_LENGTH = [];
@@ -74,7 +74,7 @@ export function indexToPassword(index) {
   // Find which length this index corresponds to
   let length = 4;
   let startIndex = 0n;
-  
+
   for (let i = 0; i < PASSWORDS_PER_LENGTH.length; i++) {
     const passwordsInThisLength = PASSWORDS_PER_LENGTH[i];
     if (index < startIndex + passwordsInThisLength) {
@@ -90,17 +90,17 @@ export function indexToPassword(index) {
 
   // Calculate the position within this length
   const positionInLength = index - startIndex;
-  
+
   // Convert position to password
   let password = "";
   let remaining = positionInLength;
-  
+
   for (let i = 0; i < length; i++) {
     const charIndex = Number(remaining % CHAR_COUNT);
     password = CHARS[charIndex] + password;
     remaining = remaining / CHAR_COUNT;
   }
-  
+
   return password;
 }
 
@@ -126,7 +126,7 @@ export function passwordToIndex(password) {
   // Add the cumulative passwords from shorter lengths
   const length = password.length;
   const startIndex = CUMULATIVE_PASSWORDS[length - 4];
-  
+
   return startIndex + positionInLength;
 }
 


### PR DESCRIPTION
This is the number of characters and thus contributes to the base in the calculation of the UUID. Having this correction will be good for people who choose to try and reverse engineer this.

Hint:
An optimization is knowing that offset % base == 0 means that there is a padding of a's.